### PR TITLE
fix nrc links to deal with cert problem

### DIFF
--- a/config/dev/agency_endpoints.json
+++ b/config/dev/agency_endpoints.json
@@ -122,7 +122,7 @@
   "id": 21,
   "name": "Nuclear Regulatory Commission",
   "acronym": "NRC",
-  "website": "https://nrc.gov/",
+  "website": "https://www.nrc.gov/",
   "code_url": "/data/fallback/NRC.json"
 }, {
   "id": 22,

--- a/config/prod/agency_endpoints.json
+++ b/config/prod/agency_endpoints.json
@@ -122,8 +122,8 @@
   "id": 21,
   "name": "Nuclear Regulatory Commission",
   "acronym": "NRC",
-  "website": "https://nrc.gov/",
-  "code_url": "https://nrc.gov/code.json"
+  "website": "https://www.nrc.gov/",
+  "code_url": "https://www.nrc.gov/code.json"
 }, {
   "id": 22,
   "name": "Office of Personnel Management",


### PR DESCRIPTION
The nrc.gov SSL cert is valid for www.nrc.gov but not for the second level domain itself.  Working around that here.