### PR TITLE
Test "/repos" route with new mock ES adapter

### DIFF
--- a/app.js
+++ b/app.js
@@ -455,8 +455,11 @@ app.use(function(err, req, res, next) {
                             SERVER
  * ------------------------------------------------------------------ */
 
-// start the server
-app.listen(port);
+// start the server, but only if we're not in the middle of a test
+if(!module.parent) {
+  app.listen(port);
+}
+
 // schedule the interval at which indexings should happen
 index_interval = config.INDEX_INTERVAL_SECONDS;
 if (index_interval) {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "mocha": "2.4.5",
     "mocha-junit-reporter": "^1.13.0",
     "nyc": "^10.3.2",
+    "proxyquire": "^1.8.0",
     "supertest": "^3.0.0"
   },
   "engines": {

--- a/test/integration/repos_test.js
+++ b/test/integration/repos_test.js
@@ -1,0 +1,71 @@
+// Tests for the /repos endpoint
+
+const mockAdapter = require('../../utils/search_adapters/testable_elasticsearch_adapter');
+const request = require('supertest');
+const proxyquire = require('proxyquire');
+
+describe('/repos endpoint', () => {
+  var app, response;
+
+  before(() => {
+    // Load the app, but replace the ES adapter
+    app = proxyquire('../../app', {
+      './utils/search_adapters/elasticsearch_adapter': mockAdapter
+    });
+
+  });
+
+  it('responds with a 200', (done) => {
+    // Set the response returned by our fake ElasticSearch DB.
+    // (esResponses defined below)
+    mockAdapter.setResponse(esResponses.basic);
+
+    request(app)
+      .get('/api/0.1/repos')
+      .expect(200)
+      .expect(() => {
+        // Purely to show how to use the MockAdapter:
+        // Let's see the query that was sent to ES during this request.
+        console.log('Logged search query:', mockAdapter.getSearchArgs());
+        // Request/response is async, so any code that works with the
+        // response, or depends on the query having been run, needs to
+        // live in a Promise-handling method
+      })
+      .end(done);
+  });
+
+  describe('the output JSON structure', () => {
+    var structure;
+
+    before(() => {
+      mockAdapter.setResponse(esResponses.basic);
+    });
+
+    it('includes a "total" count of 3', (done) => {
+      // See supertest documentation for this assertion style
+      request(app).get('/api/0.1/repos')
+        .expect((res) => {
+          if(!('total' in res.body)) {
+            throw new Error('No "total" attribute in body');
+          }
+          if(res.body.total != 3) {
+            throw new Error('total != 3');
+          }
+        })
+        .end(done);
+    });
+  });
+});
+
+const esResponses = {
+  basic: {
+    hits: {
+      total: 3,
+      hits: [
+        {
+          repos: []
+        }
+      ]
+    }
+  }
+};

--- a/utils/search_adapters/testable_elasticsearch_adapter.js
+++ b/utils/search_adapters/testable_elasticsearch_adapter.js
@@ -1,28 +1,64 @@
-const ElasticSearch                 = require("elasticsearch");
 const BaseElasticsearchAdapter      = require("./base_elasticsearch_adapter");
 
 /**
- * Represents the client that should be used for integration tests 
+ * Represents the client that should be used for integration tests.
+ * The adapter creates a MockClient which reads and stores the received
+ * queries and pre-defined responses from the Adapter.
+ * (We use the adapter as the store since it's the interface used
+ * by the app and the tests, and clients may be recreated.)
  * 
  * @class ElasticsearchAdapter
  * @extends {BaseElasticsearchAdapter}
  */
 class TestableElasticsearchAdapter extends BaseElasticsearchAdapter {
 
-    /**
-     * Creates an instance of ElasticsearchAdapter.
-     * 
-     */
-    constructor() {
-        super();
+  /**
+   * Sets up variables for recording the query and delivering
+   * an expected error value and response.
+   */
+  constructor() {
+    super();
+    this.searchArgs = null;
+    this.response = null;
+    this.error = null;
+  }
 
-        let hosts = this.getHostsFromConfig();
+  setResponse(response) {
+    this.response = response;
+  }
 
-        this.client = new ElasticSearch.Client({
-            host: hosts,
-            log: 'error'
-        });
-    }
+  setError(error) {
+    this.error = error;
+  }
+
+  getClient() {
+    return new MockClient(this);
+  }
+
+  getSearchArgs() {
+    return this.searchArgs;
+  }
+}
+
+class MockClient {
+
+  /**
+   * Hang onto the adapter reference so that we can get/set
+   * queries and responses.
+   */
+  constructor(adapter) {
+    this.adapter = adapter;
+  }
+
+  /**
+   * Records query arguments, then sends the previously-set 
+   * error and response to the callback.
+   */
+  search(args, callback) {
+    this.adapter.searchArgs = args;
+    callback(this.adapter.error, this.adapter.response);
+  }
+
 }
 
 let exportedInstance = new TestableElasticsearchAdapter()


### PR DESCRIPTION
This fills out the shell of the `testable_elasticsearch_adapter` as an ES adapter mock that can be used in tests. There's also an example test showing how to use it with `supertest`.

@okamanda Can you take a look at this and see if it makes sense? I added a load of comments but I suspect it still may be fairly opaque, especially because the `supertest` chaining style can be pretty messy.