### PR TITLE
Reduce the excessive amounts of logging occurring in the API.

### DIFF
--- a/scripts/index/repo/index.js
+++ b/scripts/index/repo/index.js
@@ -58,7 +58,7 @@ class Indexer {
       }
     ], (err, status) => {
       if (err) {
-        this.logger.info("Errors encountered. Exiting.");
+        this.logger.error(err);
       } else {
         this.logger.info("Finished indexing:", status);
       }

--- a/scripts/index/term/index.js
+++ b/scripts/index/term/index.js
@@ -55,7 +55,7 @@ class Indexer {
       }
     ], (err, status) => {
       if (err) {
-        this.logger.info("Errors encountered. Exiting.");
+        this.logger.error(err);
       } else {
         this.logger.info("Finished indexing", status);
       }

--- a/services/formatter/index.js
+++ b/services/formatter/index.js
@@ -3,13 +3,13 @@
   FORMATTER: a service which formats json objects, adding new fields and mod-
   ifying existing ones as necessary for consumption by the API
 
-  There are methods that make extra calls to the GitHub API for repo metadata. 
+  There are methods that make extra calls to the GitHub API for repo metadata.
   However, most of these calls are currently turned off in the code since the
   number of calls generated exceeds the existing API limits.
 
   TODO:  Ideally this code should be rewritten to use the new GitHub API v4
-  (GraphQL), which should end up making much fewer calls. At time of writing, 
-  the v4 API has no equivalent to the v3 "/contributors" endpoint, and the 
+  (GraphQL), which should end up making much fewer calls. At time of writing,
+  the v4 API has no equivalent to the v3 "/contributors" endpoint, and the
   "/events" endpoint is split over multiple objects based on the subject of
   the event (issues, forks, pull requests, etc.)
 
@@ -386,7 +386,7 @@ class Formatter {
         if (err) {
           Logger.error("initial language request error: " + err);
         } else {
-          logger.info('body', body);
+          logger.debug('body', body);
           etag = response.headers["etag"];
           lastupdated = response.headers["last-modified"];
         }
@@ -469,13 +469,13 @@ class Formatter {
     let formattedRepo;
     try {
       formattedRepo = this._formatRepo(repo);
-      logger.info('formatted repo', formattedRepo);
+      logger.debug('formatted repo', formattedRepo);
     } catch (err) {
       this.logger.error(`Error when formatting repo: ${err}`);
       return callback(err, repo);
     }
 
-    this.logger.info(`Formatted repo ${repo.name} (${repo.repoID}).`);
+    this.logger.debug(`Formatted repo ${repo.name} (${repo.repoID}).`);
     return callback(null, repo);
   }
 }

--- a/services/indexer/abstract_index_tool.js
+++ b/services/indexer/abstract_index_tool.js
@@ -48,10 +48,10 @@ class AbstractIndexTool {
     }, (err, response, status) => {
       let indices = new Array();
       if(err) {
-        this.logger.error(err); 
+        this.logger.error(err);
       } else {
         if (status) {
-          this.logger.info('Status', status);
+          this.logger.debug('Status', status);
         }
         _.forEach(response, function(item, key) {
           if (_.has(item, ['aliases', aliasName])) {
@@ -76,10 +76,10 @@ class AbstractIndexTool {
       name: aliasName
     }, (err, response, status) => {
       if (err) {
-        this.logger.error(err); 
+        this.logger.error(err);
       }
       if (status) {
-        this.logger.info('Status', status);
+        this.logger.debug('Status', status);
       }
       return callback(err, response);
     });

--- a/services/indexer/abstract_indexer.js
+++ b/services/indexer/abstract_indexer.js
@@ -50,9 +50,9 @@ class AbstractIndexer {
       index: this.esIndex
     }, (err, response, status) => {
       if (err) {
-        this.logger.error(err); 
+        this.logger.error(err);
       }
-      this.logger.info(status);
+      this.logger.debug(status);
       return callback(err, response);
     });
   }
@@ -64,9 +64,9 @@ class AbstractIndexer {
       body: this.esSettings
     }, (err, response, status) => {
       if(err) {
-        this.logger.error(err); 
+        this.logger.error(err);
       }
-      this.logger.info(status);
+      this.logger.debug(status);
       return callback(err, response);
     });
   }
@@ -76,9 +76,9 @@ class AbstractIndexer {
       index: this.esIndex
     }, (err, response, status) => {
       if(err) {
-        this.logger.error(err); 
+        this.logger.error(err);
       }
-      this.logger.info(status);
+      this.logger.debug(status);
       return callback(err, response);
     });
   }
@@ -86,9 +86,9 @@ class AbstractIndexer {
   indexDocument(doc, callback) {
     this.client.index(doc, (err, response, status) => {
       if(err) {
-        this.logger.error(err); 
+        this.logger.error(err);
       }
-      this.logger.info(status);
+      this.logger.debug(status);
       return callback(err, response);
     });
   }
@@ -101,9 +101,9 @@ class AbstractIndexer {
       body: this.esMapping
     }, (err, response, status) => {
       if(err) {
-        this.logger.error(err); 
+        this.logger.error(err);
       }
-      this.logger.info(status);
+      this.logger.debug(status);
       return callback(err, response);
     });
   }

--- a/services/indexer/alias_swapper.js
+++ b/services/indexer/alias_swapper.js
@@ -46,10 +46,10 @@ class AliasSwapper extends AbstractIndexTool {
       }
     }, (err, response, status) => {
       if(err) {
-        this.logger.error(err); 
+        this.logger.error(err);
       }
       if (status) {
-        this.logger.info('Status', status);
+        this.logger.debug('Status', status);
       }
       return callback(err, response);
     });
@@ -73,7 +73,7 @@ class AliasSwapper extends AbstractIndexTool {
     async.waterfall([
       //Get indexes for repo alias
       (next) => {
-        swapper.aliasExists(repoIndexInfo.esAlias, next); 
+        swapper.aliasExists(repoIndexInfo.esAlias, next);
       },
       (exists, next) => {
         if(exists) {
@@ -114,7 +114,7 @@ class AliasSwapper extends AbstractIndexTool {
       }
     ], (err) => {
       if(err) {
-        swapper.logger.error(err); 
+        swapper.logger.error(err);
       }
       swapper.logger.info(`Finished swapping aliases.`);
       return callback(err);

--- a/services/indexer/index_cleaner.js
+++ b/services/indexer/index_cleaner.js
@@ -66,7 +66,7 @@ class IndexCleaner extends AbstractIndexTool {
         return callback(err, false);
       } else {
         if (status) {
-          this.logger.info('Status', status);
+          this.logger.debug('Status', status);
         }
         let indices = [];
 
@@ -95,7 +95,7 @@ class IndexCleaner extends AbstractIndexTool {
   filterAliasedIndices(aliasName, indices, callback) {
     this.getIndexesForAlias(aliasName, (err, aliasIndices) => {
       if (err) {
-        return callback(err, false); 
+        return callback(err, false);
       }
 
       return callback(false, _.difference(indices, aliasIndices));
@@ -116,7 +116,7 @@ class IndexCleaner extends AbstractIndexTool {
       if (err) {
         this.logger.error('Error', err);
       } else if (status) {
-        this.logger.info('Status', status);
+        this.logger.debug('Status', status);
       }
       return callback(err);
     });
@@ -132,10 +132,10 @@ class IndexCleaner extends AbstractIndexTool {
 
     async.waterfall([
       (next) => {
-        this.getIndices(aliasName, daysToKeep, next); 
+        this.getIndices(aliasName, daysToKeep, next);
       }, //Gets all indices older than 7 days
       (oldIndices, next) => {
-        this.filterAliasedIndices(aliasName, oldIndices, next); 
+        this.filterAliasedIndices(aliasName, oldIndices, next);
       },
       (filteredIndices, next) => {
         if (filteredIndices.length > 0) {
@@ -146,7 +146,7 @@ class IndexCleaner extends AbstractIndexTool {
       }
     ], (err) => {
       if(err) {
-        this.logger.error(err); 
+        this.logger.error(err);
       }
       this.logger.info(`Finished cleaning indices for: (${aliasName}).`);
       return callback(err);
@@ -175,7 +175,7 @@ class IndexCleaner extends AbstractIndexTool {
 
     cleaner.cleanIndicesForAlias(repoAlias, daysToKeep, (err) => {
       if(err) {
-        cleaner.logger.error(err); 
+        cleaner.logger.error(err);
       }
       cleaner.logger.info(`Finished cleaning indices.`);
       return callback(err);

--- a/services/indexer/index_optimizer.js
+++ b/services/indexer/index_optimizer.js
@@ -47,10 +47,10 @@ class IndexOptimizer extends AbstractIndexTool {
       requestTimeout: 90000
     }, (err, response, status) => {
       if(err) {
-        this.logger.error(err); 
+        this.logger.error(err);
       }
       if (status) {
-        this.logger.info('Status', status);
+        this.logger.debug('Status', status);
       }
       return callback(err, response);
     });
@@ -71,7 +71,7 @@ class IndexOptimizer extends AbstractIndexTool {
 
     optimizer.forceMerge(repoIndexInfo.esIndex, (err) => {
       if(err) {
-        optimizer.logger.error(err); 
+        optimizer.logger.error(err);
       }
       optimizer.logger.info(`Finished optimizing indices.`);
       return callback(err);

--- a/services/indexer/term/index.js
+++ b/services/indexer/term/index.js
@@ -34,7 +34,7 @@ class RepoTermIndexerStream extends Writable {
 
   _indexTerm(term, done) {
     let id = `${term.term_key}_${term.term_type}`;
-    this.logger.info(
+    this.logger.debug(
       `Indexing term (${id}).`);
     this.termIndexer.indexDocument({
       "index": this.termIndexer.esIndex,
@@ -46,7 +46,7 @@ class RepoTermIndexerStream extends Writable {
         this.logger.error(err);
       }
       if (status) {
-        this.logger.info('Status', status);
+        this.logger.debug('Status', status);
       }
       this.termIndexer.indexCounter++;
 
@@ -95,7 +95,7 @@ class TermIndexer extends AbstractIndexer {
     indexer.logger.info(`Started indexing (${indexer.esType}) indices.`);
     async.waterfall([
       (next) => {
-        indexer.indexExists(next); 
+        indexer.indexExists(next);
       },
       (exists, next) => {
         if(exists) {
@@ -105,17 +105,17 @@ class TermIndexer extends AbstractIndexer {
         }
       },
       (response, next) => {
-        indexer.initIndex(next); 
+        indexer.initIndex(next);
       },
       (response, next) => {
-        indexer.initMapping(next); 
+        indexer.initMapping(next);
       },
       (response, next) => {
-        indexer.indexTerms(next); 
+        indexer.indexTerms(next);
       }
     ], (err) => {
       if(err) {
-        indexer.logger.error(err); 
+        indexer.logger.error(err);
       }
       indexer.logger.info(`Finished indexing (${indexer.esType}) indices.`);
       return callback(err, {

--- a/services/indexer/term/repo_term_loader_stream.js
+++ b/services/indexer/term/repo_term_loader_stream.js
@@ -26,7 +26,7 @@ class RepoTermLoaderStream extends Transform {
   }
 
   _loadTermsFromRepo(repo, callback) {
-    this.logger.info(`Loading terms from repo (${repo.repoID})...`);
+    this.logger.debug(`Loading terms from repo (${repo.repoID})...`);
 
     const _loadTerm = (termType, termVal) => {
       termVal = termVal.toLowerCase();
@@ -69,7 +69,7 @@ class RepoTermLoaderStream extends Transform {
     this.logger.info(`Pushing term objects to stream...`);
     _.forOwn(this.terms, (termTypeObj, termType) => {
       _.forOwn(termTypeObj, (termCount, termName) => {
-        this.logger.info(`Pushing term [${termType}](${termName})...`);
+        this.logger.debug(`Pushing term [${termType}](${termName})...`);
         let termCountNormalized = termCount / this.termMaxes[termType];
         let term = {
           term_key: termName,

--- a/services/validator/index.js
+++ b/services/validator/index.js
@@ -38,12 +38,12 @@ class Validator {
     // validate for errors
     let valid = this.validators["repo"]["relaxed"](repo);
     if (valid) {
-      this.logger.info(`Successfully validated repo data for ${repo.name} (${repo.repoID}).`);
+      this.logger.debug(`Successfully validated repo data for ${repo.name} (${repo.repoID}).`);
       callback(null, []);
     } else {
-      this.logger.info(`Encountered errors when validating repo data for ${repo.name} (${repo.repoID}).`);
+      this.logger.debug(`Encountered errors when validating repo data for ${repo.name} (${repo.repoID}).`);
       let errors = this.validators["repo"]["relaxed"].errors;
-      this.logger.error(errors);
+      this.logger.debug(errors);
       callback(null, errors);
     }
   }
@@ -55,9 +55,9 @@ class Validator {
       // this.logger.info(`Didn't find any warnings for ${repo.name} (${repo.repoID}).`);
       callback(null, []);
     } else {
-      this.logger.info(`Encountered warnings when validating repo data for ${repo.name} (${repo.repoID}).`);
+      this.logger.debug(`Encountered warnings when validating repo data for ${repo.name} (${repo.repoID}).`);
       let warnings = this.validators["repo"]["strict"].errors;
-      this.logger.warning(warnings);
+      this.logger.debug(warnings);
       callback(null, warnings);
     }
   }
@@ -69,10 +69,10 @@ class Validator {
       // this.logger.info(`Didn't find any warnings for ${repo.name} (${repo.repoID}).`);
       callback(null, []);
     } else {
-      this.logger.info(`Encountered potential enhancements when validating repo data for ${repo.name}`
+      this.logger.debug(`Encountered potential enhancements when validating repo data for ${repo.name}`
         + `(${repo.repoID}).`);
       let enhancements = this.validators["repo"]["enhanced"].errors;
-      this.logger.warning(enhancements);
+      this.logger.debug(enhancements);
       callback(null, enhancements);
     }
   }
@@ -89,7 +89,7 @@ class Validator {
         if (error.params && error.params.missingProperty === "repository") {
           return false;
         }
-        
+
       }
       return true;
     });
@@ -111,10 +111,6 @@ class Validator {
           this.logger("removing warning for closed source repo with license===null");
           return false;
         }
-        this.logger.info(warning.dataPath);       
-        //if (warning.params && warning.dataPath === ".description" && warning.params.type === "string"){
-        //  return false;
-       
       }
       if (warning.dataPath === ".license" && repo.license === null) {
         this.logger("removing warning for closed source repo with repository===null");
@@ -137,7 +133,7 @@ class Validator {
         if (enhancement.params && enhancement.params.missingProperty === "repository") {
           return false;
         }
-        //schema v1.0.1 requires the license element but technically allows it to be null, even for OSS. 
+        //schema v1.0.1 requires the license element but technically allows it to be null, even for OSS.
         //nudge here to include license info for OSS
         if (enhancement.dataPath === ".license" && repo.license === null) {
           this.logger("removing enhancement request for closed source repo with repository===null");
@@ -147,10 +143,6 @@ class Validator {
           this.logger("removing enhancement request for closed source repo with license===null");
           return false;
         }
-        this.logger.info(enhancement.dataPath);       
-        //if (warning.params && warning.dataPath === ".description" && warning.params.type === "string"){
-        //  return false;
-       
       }
 
       return true;
@@ -158,7 +150,7 @@ class Validator {
   }
 
   validateRepo(repo, callback) {
-    this.logger.info(`Validating repo data for ${repo.name} (${repo.repoID})...`);
+    this.logger.debug(`Validating repo data for ${repo.name} (${repo.repoID})...`);
 
     let result = {
       "repoID": repo.repoID,
@@ -196,9 +188,9 @@ class Validator {
       (validationEnhancements, next) => {
         // remove errors and warnings from enhancements
         let enhancements = Utils.removeDupes(validationEnhancements, result.issues.errors);
-        
+
         enhancements = Utils.removeDupes(enhancements, result.issues.warnings);
-        
+
         // remove special case enhancements
         enhancements = this._removeSpecialCaseEnhancements(repo, enhancements);
 
@@ -219,7 +211,7 @@ class Validator {
       }
       // NOTE: need to buffer because ajs' promises don't work
       setTimeout(() => {
-        callback(err, result); 
+        callback(err, result);
       }, 10);
       // return callback(err, result);
     });

--- a/test/services/indexer/term/repo_term_loader_stream_test.js
+++ b/test/services/indexer/term/repo_term_loader_stream_test.js
@@ -3,7 +3,8 @@ const RepoTermLoaderStream = require("../../../../services/indexer/term/repo_ter
 describe("RepoTermLoaderStream", () => {
   let termIndexerMock = {
     logger: {
-      info: function() {}
+      info: function() {},
+      debug: function() {}
     }
   };
 

--- a/utils/search_stream.js
+++ b/utils/search_stream.js
@@ -26,7 +26,7 @@ class SearchStream extends Readable {
         "from": this.from
       }
     });
-    this.logger.info(`Streaming search for:`, searchQuery);
+    this.logger.debug(`Streaming search for:`, searchQuery);
     this.current = this.from;
     this.client.search(searchQuery, (err, res) => {
       if (err) {


### PR DESCRIPTION
### Why?

* Our logging levels on our deployed servers are excessive, placing thousands of logged messages while handling code.json files

### What Changed?

* My editor removed trailing whitespace, not a bad thing!
* Changed some error messages that were being logged as `info` up to `error`. As a side effect, this may cause double logging of errors, but looking through the code that it's calling, there's also a possibility an error could be thrown and just silently falls through the cracks. Would rather double logging than not logging.
* Changed many frequent messages from `info` to `debug`. It was primarily a judgment call, but in this case anything that happens many times during a request is now a `debug` call, whereas messages that pertain to the status of a request are `info`.
* We no longer log validation errors as `errors` or `warnings`, because they are not considered errors or warnings of how our application is running.