### PR TITLE
Add .gitallowed

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -1,0 +1,1 @@
+password\s*:\s*githubConfig.password


### PR DESCRIPTION
# Why

There are specific patterns that would violate the patterns found in [code-gov-gitsecretpatterns](https://github.com/presidential-innovation-fellows/code-gov-gitsecretpatterns) that should be allowed to pass. For example `password = process.env.GITHUB_PASSWORD`.

# What changed

A `.gitallowed` file was added to the project so these special case patterns can be defined as allowed and not have to have every developer add them to their git-config.