### PR TITLE
Change circleci deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - deploy:
           command: |
             if [ "${CIRCLE_TAG}" =~ "${DEPLOY_TAG_PATTERN}" ]; then
-              cf login -a ${CF_URL} -u ${CF_DEPLOYER_USER} -p ${CF_PASS} -o ${ORG} -s ${CF_PROD_SPACE}
+              cf login -a ${CF_URL} -u ${CF_DEPLOYER_USER} -p ${CF_PASS} -o ${CF_ORG} -s ${CF_PROD_SPACE}
               cf push
             fi
 
@@ -55,6 +55,6 @@ jobs:
       - deploy:
           command: |
             if [ "${CIRCLE_BRANCH}" == "${STAGING_DEPLOY_BRANCH}" ]; then
-              cf login -a ${CF_URL} -u ${CF_DEPLOYER_USER} -p ${CF_PASS} -o ${ORG} -s ${CF_STAGING_SPACE}
+              cf login -a ${CF_URL} -u ${CF_DEPLOYER_USER} -p ${CF_PASS} -o ${CF_ORG} -s ${CF_STAGING_SPACE}
               cf push
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - deploy:
           command: |
             if [ "${CIRCLE_TAG}" =~ "${DEPLOY_TAG_PATTERN}" ]; then
-              cf login -a ${CF_URL} -u ${CF_DEPLOYER_USER} -p ${CF_PASS} -o ${CF_ORG} -s ${CF_PROD_SPACE}
+              cf login -a ${CF_URL} -u ${CF_PRODUCTION_DEPLOYER} -p ${CF_PRODUCTION_DEPLOYER_PASS} -o ${CF_ORG} -s ${CF_PRODUCTION_SPACE}
               cf push
             fi
 
@@ -55,6 +55,6 @@ jobs:
       - deploy:
           command: |
             if [ "${CIRCLE_BRANCH}" == "${STAGING_DEPLOY_BRANCH}" ]; then
-              cf login -a ${CF_URL} -u ${CF_DEPLOYER_USER} -p ${CF_PASS} -o ${CF_ORG} -s ${CF_STAGING_SPACE}
+              cf login -a ${CF_URL} -u ${CF_STAGING_DEPLOYER} -p ${CF_STAGING_DEPLOYER_PASS} -o ${CF_ORG} -s ${CF_STAGING_SPACE}
               cf push
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,23 +46,15 @@ jobs:
       # Production deployment.
       - deploy:
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              cf login -a ${CF_URL} -u ${CF_DEPLOYER_USER} -p ${CF_PASS} -o ORG -s ${CF_PROD_SPACE}
+            if [ "${CIRCLE_TAG}" =~ "${DEPLOY_TAG_PATTERN}" ]; then
+              cf login -a ${CF_URL} -u ${CF_DEPLOYER_USER} -p ${CF_PASS} -o ${ORG} -s ${CF_PROD_SPACE}
               cf push
             fi
-      
+
       # Staging deployment.
       - deploy:
           command: |
-            if [ "${CIRCLE_BRANCH}" == "staging" ]; then
-              cf login -a ${CF_URL} -u ${CF_DEPLOYER_USER} -p ${CF_PASS} -o ORG -s ${CF_STAGING_SPACE}
-              cf push
-            fi
-      
-      # Development deployment.
-      - deploy:
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "development" ]; then
-              cf login -a ${CF_URL} -u ${CF_DEPLOYER_USER} -p ${CF_PASS} -o ORG -s ${CF_DEV_SPACE}
+            if [ "${CIRCLE_BRANCH}" == "${STAGING_DEPLOY_BRANCH}" ]; then
+              cf login -a ${CF_URL} -u ${CF_DEPLOYER_USER} -p ${CF_PASS} -o ${ORG} -s ${CF_STAGING_SPACE}
               cf push
             fi


### PR DESCRIPTION
# Why

We changed the branching and deployment strategy. The CircleCI config had to reflect this new strategy.

# What changed

The deployment sections of the CircleCI config where changed. - a15feea
- Changed production deploy to use git tags.
- Deploy tag will be specified by CircleCI environment variable.
- Changed staging branch to be configured by CircleCI environment variable.
- Fixed ORG variabale to have correct syntax.
- Changed the ORG variable to CF_ORG

# Issue

Closes #59 

# Update

* Changed deploy user credential vars - 86e5dd2
    There has been some changes with the deploy user credentials. Each space in Cloud.gov needs to have ti's own deployment user with it's own credentials. The credential variables have been changed in the CircleCI script to reflect this.