### PR TITLE
Changed indexer schedule time to be daily.

### DIFF
--- a/config/prod/index.json
+++ b/config/prod/index.json
@@ -6,7 +6,7 @@
   "DIFFED_DIR": "/data/diffed",
   "FALLBACK_DIR": "/data/fallback",
   "AGENCIES_TO_OMIT_FROM_STATUS": ["EOP"],
-  "INDEX_INTERVAL_SECONDS": 3600,
+  "INDEX_INTERVAL_SECONDS": 86400,
   "TERM_TYPES_TO_INDEX": [
     "name",
     "agency.name",


### PR DESCRIPTION
# Why

The indexer is running every hour and is creating disk problems.

# What changed

The `INDEX_INTERVAL_SECONDS` production config key value was changed to represent a daily schedule.

# Additional notes

This PR is to substitute #93. PR #93 would introduce credentials into the git history.